### PR TITLE
feat: add rename functionality

### DIFF
--- a/lidar_qc/cli/commands/rename.py
+++ b/lidar_qc/cli/commands/rename.py
@@ -48,7 +48,7 @@ def rename(
     called_from_cli: Annotated[bool, typer.Option(hidden=True)] = True,
 ):
     """
-    Rename a collection of files of either DEM, DSM or CL2.
+    Rename DEM, DSM or Point Cloud files in accordance with section 9.2 in the New Zealand National Aerial LiDAR Base Specification.
     """
 
     # Make dry-run always verbose

--- a/lidar_qc/cli/commands/rename.py
+++ b/lidar_qc/cli/commands/rename.py
@@ -51,6 +51,7 @@ def rename(
     Rename a collection of files of either DEM, DSM or CL2.
     """
 
+    # Make dry-run always verbose
     if not write:
         verbose = True
 
@@ -65,13 +66,15 @@ def rename(
     if not write:
         logger.info('This is a dry-run, no files are being modified. To execute rename, use --write')
 
-    # find raster and pc sub-directories
+    # find raster and point cloud sub-directories
     raw_data_dirs = find_data_subdirs(input_dir,[],[])
 
     for raw_data_dir, cls in raw_data_dirs:
+        # get all the files from the subdirectories which match glob_pattern
         files: list[Path] = list(raw_data_dir.glob(cls.glob_pattern))
 
-        if write is None and limit is not None: # apply limit for dry-run if specified
+        # apply limit for dry-run if specified
+        if write is None and limit is not None: 
             files = files[:limit]
 
         file_infos = []
@@ -96,14 +99,19 @@ def rename(
 
         if file_infos:
             for file_info in file_infos:
-
+                
+                # Get the official tile for this file
                 official_tile = file_info.get_correct_tile().feature_properties()
 
+                # Define if this file type is Raster or Point Cloud, to help determine later which prefix and suffix to use
                 product_type = file_info.product_type.value if file_info.file_type == 'Raster' else 'CL2' if file_info.file_type == 'PointCloud' else None
 
+                # Build new file path
                 current_file_path = os.path.join(raw_data_dir, file_info.file_name + file_info.file_extension)
                 new_file_path = os.path.join(raw_data_dir, product_type + '_' + official_tile["sheet_code_id"] + '_' + survey_start_year + '_' + str(official_tile["scale"]) + '_' + official_tile["tile"] + file_info.file_extension)           
                 
+                
+                # If raster, accomodate tfw files if they exist.
                 tfw = False
                 if file_info.file_type == 'Raster':
                     if os.path.exists(Path(current_file_path).with_suffix('.tfw')):
@@ -111,13 +119,13 @@ def rename(
                         current_tfw_file = Path(current_file_path).with_suffix('.tfw')
                         new_tfw_file = Path(new_file_path).with_suffix('.tfw')
                         
-                
+                # Output file name change ito logger if this is a dry-run
                 if not write:
                     logger.debug(f'{current_file_path} --> {new_file_path}')
                     if tfw:
                         logger.debug(f'{current_tfw_file} --> {new_tfw_file}')
                 
-
+                # Execute write
                 if write:
                     rename_file(current_file_path,new_file_path)
                     if tfw:

--- a/lidar_qc/cli/commands/rename.py
+++ b/lidar_qc/cli/commands/rename.py
@@ -1,0 +1,128 @@
+import os
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from lidar_qc.cli.timer import end_timer, start_timer
+from lidar_qc.cli.validations import find_data_subdirs, validate_year
+from lidar_qc.log import configure_logging
+from lidar_qc.parallel import run_in_parallel
+from lidar_qc.util import is_point_cloud_dir, is_raster_dir, rename_file
+
+
+def rename(
+    input_dir: Path = typer.Option(
+        ...,
+        "--input",
+        "-i",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+        help="Path to directory containing subfolders of raster and point cloud files",
+        show_default=False
+    ),
+    survey_start_year: str = typer.Option(None,"--year","-y", prompt_required=True,help="Start year of survey", callback=validate_year,show_default=False),
+    write: Optional[bool] = typer.Option(
+        None,
+        "--write",
+        "-w",
+        file_okay=False,
+        dir_okay=False,
+        help="Confirm overwrite",
+    ),
+    limit: Optional[int] = typer.Option(
+        None,
+        "--limit",
+        "-l",
+        help="Limit the amount of files dry-run is run against. If not specified, there is no limit.",
+        show_default=False
+    ),
+    stats: bool = False,
+    verbose: bool = False,
+    log_file: Optional[Path] = typer.Option(default=None),
+    logger_=typer.Option(default=None, hidden=True),
+    called_from_cli: Annotated[bool, typer.Option(hidden=True)] = True,
+):
+    """
+    Rename a collection of files of either DEM, DSM or CL2.
+    """
+
+    if not write:
+        verbose = True
+
+    if logger_ is None:
+        logger: Logger = configure_logging(verbose, log_file)
+    else:
+        logger = logger_
+    if called_from_cli:
+        start_time = start_timer()
+
+
+    if not write:
+        logger.info('This is a dry-run, no files are being modified. To execute rename, use --write')
+
+    # find raster and pc sub-directories
+    raw_data_dirs = find_data_subdirs(input_dir,[],[])
+
+    for raw_data_dir, cls in raw_data_dirs:
+        files: list[Path] = list(raw_data_dir.glob(cls.glob_pattern))
+
+        if write is None and limit is not None: # apply limit for dry-run if specified
+            files = files[:limit]
+
+        file_infos = []
+
+        extra_kwargs: dict[str, Any] = {"supplied_tile_index_file": None}
+        if is_point_cloud_dir(raw_data_dir.name):
+            extra_kwargs["no_lasinfo_txt"] = True
+        
+        file_infos, file_info_errors = run_in_parallel(
+            func=cls.from_file,
+            items=files,
+            extra_kwargs=extra_kwargs,
+            start_message=f"Renaming files in '{raw_data_dir.name}' ...",
+            pbar_unit="tile",
+        )
+
+        if file_info_errors:
+            logger.error(
+                f"{len(file_info_errors)} files were unable to be parsed from {len(files)} files matching {cls.glob_pattern} found in {raw_data_dir}"
+            )
+
+
+        if file_infos:
+            for file_info in file_infos:
+
+                official_tile = file_info.get_correct_tile().feature_properties()
+
+                product_type = file_info.product_type.value if file_info.file_type == 'Raster' else 'CL2' if file_info.file_type == 'PointCloud' else None
+
+                current_file_path = os.path.join(raw_data_dir, file_info.file_name + file_info.file_extension)
+                new_file_path = os.path.join(raw_data_dir, product_type + '_' + official_tile["sheet_code_id"] + '_' + survey_start_year + '_' + str(official_tile["scale"]) + '_' + official_tile["tile"] + file_info.file_extension)           
+                
+                tfw = False
+                if file_info.file_type == 'Raster':
+                    if os.path.exists(Path(current_file_path).with_suffix('.tfw')):
+                        tfw = True
+                        current_tfw_file = Path(current_file_path).with_suffix('.tfw')
+                        new_tfw_file = Path(new_file_path).with_suffix('.tfw')
+                        
+                
+                if not write:
+                    logger.debug(f'{current_file_path} --> {new_file_path}')
+                    if tfw:
+                        logger.debug(f'{current_tfw_file} --> {new_tfw_file}')
+                
+
+                if write:
+                    rename_file(current_file_path,new_file_path)
+                    if tfw:
+                        rename_file(current_tfw_file,new_tfw_file)
+
+
+    logger.info(f"Renaming complete")
+

--- a/lidar_qc/cli/main.py
+++ b/lidar_qc/cli/main.py
@@ -6,6 +6,7 @@ from lidar_qc.cli.commands.density_rasters import density_raster
 from lidar_qc.cli.commands.difference_raster import difference_raster
 from lidar_qc.cli.commands.neighbour_raster import neighbour_raster
 from lidar_qc.cli.commands.psid import psid
+from lidar_qc.cli.commands.rename import rename
 
 app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
 app.command()(check_dataset)
@@ -14,6 +15,7 @@ app.command()(build_vrt)
 app.command()(density_raster)
 app.command()(neighbour_raster)
 app.command()(difference_raster)
+app.command()(rename)
 
 if __name__ == "__main__":
     app()

--- a/lidar_qc/cli/validations.py
+++ b/lidar_qc/cli/validations.py
@@ -192,3 +192,12 @@ def validate_script_progress(input_files: list[Path], output_dir: Path, item: st
         f"{len(output_files)} raster files found in {output_dir}, processing {len(folder_files_filtered)}/{len(input_files)} files for {item}"
     )
     return folder_files_filtered
+
+def validate_year(year_string: str) -> str:
+    """
+    Ensure the year that is inputted is a digit, not None and is four digits.
+    """
+    if year_string is not None and year_string.isdigit() and len(year_string) == 4:
+        return year_string
+    else:
+        raise typer.BadParameter(f"Year {year_string} is not valid")

--- a/lidar_qc/dataset_info/file_info.py
+++ b/lidar_qc/dataset_info/file_info.py
@@ -55,11 +55,12 @@ class FileInfo(BaseModel):
     Parent dataclass created using BaseModel from pydantic.
     Contains class methods which pertain to both child classes.
     """
-
+    file_type: ClassVar[str]
     glob_pattern: ClassVar[str]
     summarise_func: ClassVar
     _schema: ClassVar[dict]
     file_name: str | None
+    file_extension: str | None
     projection: str | None
     supplied_tile_index_file: Path | None
 
@@ -138,6 +139,18 @@ class FileInfo(BaseModel):
                 "2193" in self.projection,
             ]
         )
+
+    def get_correct_tile(self):
+        """
+        Uses the file polygon bounds to get a centroid which is used to get the official 1k tile, using index_tiles.py.
+        Returns True if the file name mapsheet and tile number match the official 1k tile, False if either one doesn't match.
+        """
+        try:
+            official_tile = official_tile_index.get_tile_from_point(self.bounding_box().centroid)
+        except ValueError:
+            logger.error(f"{self.file_name} is outside tile scheme")
+        
+        return official_tile       
 
     @staticmethod
     def _get_spatial_index(vector_file: Path):

--- a/lidar_qc/dataset_info/file_info.py
+++ b/lidar_qc/dataset_info/file_info.py
@@ -140,10 +140,10 @@ class FileInfo(BaseModel):
             ]
         )
 
-    def get_correct_tile(self):
+    def get_correct_tile(self) -> Dict:
         """
-        Uses the file polygon bounds to get a centroid which is used to get the official 1k tile, using index_tiles.py.
-        Returns True if the file name mapsheet and tile number match the official 1k tile, False if either one doesn't match.
+        Uses the file centroid to get the official 1k tile, using index_tiles.py.
+        Returns official tile if within tile scheme.
         """
         try:
             official_tile = official_tile_index.get_tile_from_point(self.bounding_box().centroid)

--- a/lidar_qc/dataset_info/point_cloud_file_info.py
+++ b/lidar_qc/dataset_info/point_cloud_file_info.py
@@ -21,6 +21,7 @@ class PointCloudFileInfo(FileInfo):
     Returns the dataclass instance for the file.
     """
 
+    file_type = "PointCloud"
     glob_pattern = "*.la[sz]"
     summarise_func = summarise_point_cloud_product
     _schema = {
@@ -144,6 +145,7 @@ class PointCloudFileInfo(FileInfo):
 
         data: dict[str, Any] = {}
         data["file_name"] = file.stem
+        data["file_extension"] = file.suffix
         data["supplied_tile_index_file"] = supplied_tile_index_file
 
         # Each match is either returning something or None.

--- a/lidar_qc/dataset_info/raster_file_info.py
+++ b/lidar_qc/dataset_info/raster_file_info.py
@@ -27,7 +27,7 @@ class RasterFileInfo(FileInfo):
     Child dataclass of FileInfo which stores metadata information from a raster file by parsing the output of gdalinfo.
     Returns the dataclass instance for the file.
     """
-
+    file_type = "Raster"
     glob_pattern = "*.tif"
     summarise_func = summarise_raster_product
     _schema = {
@@ -82,6 +82,7 @@ class RasterFileInfo(FileInfo):
         gdalinfo_output = gdalinfo(file)
         data: dict[str, Any] = {}
         data["file_name"] = file.stem
+        data["file_extension"] = file.suffix
         data["supplied_tile_index_file"] = supplied_tile_index_file
 
         if size := gdalinfo_output.get("size"):
@@ -166,6 +167,9 @@ class RasterFileInfo(FileInfo):
             self.coordinates_lower_right.x,
             self.coordinates_upper_left.y,
         )
+    
+    def centroid(self):
+        return self.bounding_box.centroid()
 
     def is_file_name_correct_format(self) -> bool:
         """

--- a/lidar_qc/util.py
+++ b/lidar_qc/util.py
@@ -1,3 +1,11 @@
+import os
+from pathlib import Path
+
+from lidar_qc.log import get_logger
+
+logger = get_logger()
+
+
 def is_point_cloud_dir(name: str) -> bool:
     """
     Receives folder path and returns True if point, laz, or las is in the folder name.
@@ -10,3 +18,16 @@ def is_raster_dir(name: str) -> bool:
     Receives folder path and returns True if dem or dsm is in the folder name.
     """
     return "dem" in name.lower() or "dsm" in name.lower()
+
+def rename_file(old_file_path: Path, new_file_path: Path) -> None:   
+    """
+    Rename a file
+    """ 
+    try:    
+        if os.path.exists(old_file_path):
+            os.rename(old_file_path, new_file_path)
+            logger.debug(f'renamed: {old_file_path} -> {new_file_path}')
+        else:
+            logger.error(f'{old_file_path} does not exist')
+    except Exception as err:
+        logger.error(f'Error renaming file: {err}')


### PR DESCRIPTION
New cli option called `rename`. It determines the correct file name by performing a spatial analysis on the file.

Takes the following arguments:

`--input -i` - Path to directory containing subfolders of raster and point cloud files
`--year -y`- Start year of survey 
`--write -w` - Confirms overwrite
`--limit -l` - Limits the amount of files the dry run is run against. If not specified, there is no limit.

Run on directory which contains sub-directories from raster and point cloud data.

Does a dry run initially unless `--write` or `-w` passed
